### PR TITLE
fix: persistence regression postgres not ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN cargo build --bin api
 
 FROM runtime
 COPY --from=builder /app/target/debug/api /usr/local/bin/shuttle-backend
+
 COPY docker/entrypoint.sh /bin/entrypoint.sh
+COPY docker/wait-for-pg-then /usr/bin/wait-for-pg-then
 COPY docker/supervisord.conf /usr/share/supervisord/supervisord.conf
 ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -26,5 +26,6 @@ WORKDIR /
 COPY --from=builder /app/target/debug/api /usr/local/bin/shuttle-backend
 
 COPY docker/entrypoint.sh /bin/entrypoint.sh
+COPY docker/wait-for-pg-then /usr/bin/wait-for-pg-then
 COPY docker/supervisord.conf /usr/share/supervisord/supervisord.conf
 ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -8,7 +8,7 @@ startsecs=20
 autorestart=true
 
 [program:shuttle-api]
-command=/usr/local/bin/shuttle-backend --path %(ENV_CRATES_PATH)s --bind-addr 0.0.0.0 --api-port %(ENV_API_PORT)s --proxy-port %(ENV_PROXY_PORT)s
+command=/usr/bin/wait-for-pg-then /usr/local/bin/shuttle-backend --path %(ENV_CRATES_PATH)s --bind-addr 0.0.0.0 --api-port %(ENV_API_PORT)s --proxy-port %(ENV_PROXY_PORT)s
 redirect_stderr=true
 environment=RUST_BACKTRACE="1",RUST_LOG="debug"
 startretries=3

--- a/docker/wait-for-pg-then
+++ b/docker/wait-for-pg-then
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+TIMEOUT=15
+SLEPT=0
+
+while ! pg_isready -q; do
+  echo waiting for postgres
+  sleep 1
+  SLEPT+=1
+  if [[ $SLEPT -ge $TIMEOUT ]]; then
+    echo postgres did not start in time
+    exit 1
+  fi
+done
+
+exec "$@"


### PR DESCRIPTION
This regression occurs because the job processor loop starts before postgres is ready, resulting in us not being able to acquire a connection in `db_state.ensure().await` in `deployment.rs`.

Ideally `supervisord` would have dependencies where you can start program a after program b, but alas this is an open PR: https://github.com/Supervisor/supervisor/pull/1449/files so we'll have to employ the hacky solution of sleeping the job processor thread for 20 seconds on startup.

This is not great as we will have 20 seconds of application downtime, however it is better than not having persistence at all. 

Future improvements can employ a 'retry' system in `ensure()`.