### PR TITLE
chore: remove unneeded async_trait markers

### DIFF
--- a/examples/rocket/hello-world/Cargo.lock
+++ b/examples/rocket/hello-world/Cargo.lock
@@ -572,7 +572,6 @@ dependencies = [
 name = "hello-world"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "rocket",
  "shuttle-service",
 ]

--- a/examples/rocket/hello-world/Cargo.toml
+++ b/examples/rocket/hello-world/Cargo.toml
@@ -9,6 +9,5 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
 rocket = "0.5.0-rc.1"
 shuttle-service = "0.2.4"

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -200,7 +200,6 @@ pub trait Factory: Send + Sync {
 /// The core trait of the shuttle platform. Every crate deployed to shuttle needs to implement this trait.
 ///
 /// Use the [declare_service!][crate::declare_service] macro to expose your implementation to the deployment backend.
-#[async_trait]
 pub trait Service: Send + Sync {
     /// This function is run exactly once on each instance of a deployment, prior to calling [bind][Service::bind].
     ///
@@ -269,7 +268,6 @@ for (
     }
 }
 
-#[async_trait]
 impl<T> Service for RocketService<T>
     where
         T: Send + Sync + 'static,


### PR DESCRIPTION
I just realized we had a bunch of these. So cleaning them up before they end up in code we do not want...