### PR TITLE
Added crates.io metadata to Cargo.toml

### DIFF
--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -3,6 +3,11 @@ name = "shuttle-service"
 version = "0.2.4"
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/getsynth/shuttle"
+homepage = "https://www.shuttle.rs"
+documentation = "https://docs.rs/shuttle-service"
+keywords = ["deployment", "deploy", "devops"]
+categories = ["development-tools::cargo-plugins"]
 description = "Service traits and macros to deploy on the shuttle platform (https://www.shuttle.rs/)"
 
 [lib]


### PR DESCRIPTION
Added crates.io meta fields under [package] in Cargo.toml. It makes the crate a bit more discoverable and easier to follow.

Examples of listings for crates with meta:

![image](https://user-images.githubusercontent.com/5926028/159600152-f388c2f0-88af-4b25-b3c2-4451e874528d.png)

![image](https://user-images.githubusercontent.com/5926028/159600233-e8346a8e-9924-469f-9cb4-af1fc0a19185.png)

What Shuttle looks like at the moment:

No link to the repo in the docs. I had to google it
![image](https://user-images.githubusercontent.com/5926028/159600362-3b5d8cfc-d130-4a84-8dd4-53d00183c62f.png)

![image](https://user-images.githubusercontent.com/5926028/159600431-ab557e6b-a07b-4f79-8040-cf6c6f1d2781.png)

![image](https://user-images.githubusercontent.com/5926028/159600632-e24c4119-4809-4c67-833c-80440bb199ac.png)
