### PR TITLE
Improved examples DX

### DIFF
--- a/cargo-shuttle/src/main.rs
+++ b/cargo-shuttle/src/main.rs
@@ -44,10 +44,16 @@ async fn login(login_args: LoginArgs) -> Result<()> {
         
         io::stdin().read_line(&mut input).unwrap();    
 
+        // read_line preserves CR/LF that need to be trimmed
+        let input = input.trim().to_string();
+        println!(
+            "Store the key in a safe location for future use with `cargo shuttle deploy --api-key {input}`"
+        );
+
         input
     });
 
-    config::create_with_api_key(api_key.trim().to_string())
+    config::create_with_api_key(api_key)
 }
 
 async fn auth(auth_args: AuthArgs) -> Result<()> {

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,21 +4,42 @@ Some example apps to show what you can do with shuttle.
 
 ## How to deploy the examples
 
-To deploy the examples, check out the repository locally
+To deploy the examples:
+
+1. Check out the repository locally
 
 ```bash
-$ git clone https://github.com/getsynth/shuttle.git
+git clone https://github.com/getsynth/shuttle.git
+cd shuttle
 ```
 
-navigate to an example root folder
+2. Install `cargo-shuttle` with either
+```bash
+cargo install cargo-shuttle
+```
+or
+```bash
+cargo install --path cargo-shuttle
+```
+
+3. Navigate to an example root folder
 
 ```bash
-$ cd examples/rocket/hello-world
+cd examples/rocket/hello-world
 ```
 
-open up the `Shuttle.toml` file and change the project name to something 
+4. Open up the `Shuttle.toml` file and change the project name to something 
 unique - in shuttle, projects are globally unique. Then run
 
+5. Get your API key by running
 ```bash
-$ cargo shuttle deploy
+cargo shuttle login
+```
+That will open a browser window and prompt you to connect using your GitHub account.
+Copy-paste the key into the terminal and **store it in a safe place for future use** as a CLI param (`--api_key [your key]`).
+
+6. Deploy the service with:
+
+```bash
+cargo shuttle deploy --allow-dirty
 ```

--- a/examples/rocket/hello-world/Cargo.toml
+++ b/examples/rocket/hello-world/Cargo.toml
@@ -2,6 +2,9 @@
 name = "hello-world"
 version = "0.1.0"
 edition = "2021"
+description = "Shuttle test project"
+license = "Apache 2.0"
+homepage = "https://www.shuttle.rs/"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/rocket/postgres/Cargo.toml
+++ b/examples/rocket/postgres/Cargo.toml
@@ -2,6 +2,9 @@
 name = "postgres"
 version = "0.1.0"
 edition = "2021"
+description = "Shuttle test project"
+license = "Apache 2.0"
+homepage = "https://www.shuttle.rs/"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
The instructions for running examples were missing a few steps. I filled the gaps while I was at it. 

* print a msg about saving api-key
* updated README with missed steps
* updated Cargo.toml to avoid an error msgs

![image](https://user-images.githubusercontent.com/5926028/159612182-1e822107-a5d6-4883-8b5f-38a7d9442cc7.png)

Given that we ask the devs to edit Shuttle.toml they will always have to either commit or use --allow-dirty. Might just give them that shortcut straight away.

And I added the missing meta in Cargo.toml to kill the warning.

### Unrelated

`Created At:         2022-03-23 02:12:35.044378437 UTC` in post-deploy would look better without nanoseconds 

`Created At:         2022-03-23 02:12:35 UTC`

Not sure that level of precision is needed.

