### PR TITLE
Feedback after going though deployment of example code

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,18 +7,18 @@ Some example apps to show what you can do with shuttle.
 To deploy the examples, check out the repository locally
 
 ```bash
-$ git clone https://github.com/getsynth/shuttle.git
+git clone https://github.com/getsynth/shuttle.git
 ```
 
 navigate to an example root folder
 
 ```bash
-$ cd examples/rocket/hello-world
+cd shuttle/examples/rocket/hello-world
 ```
 
 open up the `Shuttle.toml` file and change the project name to something 
 unique - in shuttle, projects are globally unique. Then run
 
 ```bash
-$ cargo shuttle deploy
+cargo shuttle deploy
 ```

--- a/www/README.md
+++ b/www/README.md
@@ -32,13 +32,13 @@ For now deployment is manual using the `vercel` CLI tool.
 Running just:
 
 ```bash
-$ vercel
+vercel
 ```
 
 in the root `www` folder will deploy to a test deployment, and:
 
 ```bash
-$ vercel --prod
+vercel --prod
 ```
 
 will deploy to production and override the current `shuttle.rs` page.


### PR DESCRIPTION
When trying out new tech for the first time, I like to keep track of the things that I notice along the way. You only get one "first time", so these observations are important to record.

When following https://docs.rs/shuttle-service/latest/shuttle_service/ I noticed:

## Observations

I can split these out into separate tickets if you want. They're all pretty low hanging fruit, so I can make PRs for them if you want.

### default installation location of hello world app isn't correctly deployed


> Your service will immediately be available at `{crate_name}.shuttleapp.rs`. For example:
```
curl https://hello-world-rocket-app.shuttleapp.rs
```

Unfortunately, this does not print:
```
Hello, world!
```

Instead, it prints:
```
could not find service for host: hello-world-rocket-app.shuttleapp.rs
```

This feels like the kind of thing that would be perfect as a post-merge-to-main CI step.

### deployment doesn't appear where you would guess 

The docs suggest that it will be at `{crate_name}.shuttleapp.rs`, when I read `crate_name`, I think of `package.name` in `Cargo.toml`, but this appears to be ignored by `cargo shuttle deploy`. It actually refers to `name` from Shuttle.toml. The output from the server says `Compiling quickinstall-stats` as if it is a crate though, so I don't know what the correct way to avoid confusion is though (maybe don't configure the name in Shuttle.toml, and instead use the name in Cargo.toml as the source of truth?)

### example app does not respond to /

When I eventually deployed, I went to https://quickinstall-stats.shuttleapp.rs (*) and it gave me a 404. After looking at the example source code, I guessed https://quickinstall-stats.shuttleapp.rs/hello

Mounting at both / and /hello works around this, but feels a bit icky, so I didn't commit it.

```rust
    rocket::build()
        .mount("/", routes![index])
        .mount("/hello", routes![index])
```

(*) I'm thinking of switching the stats server for [cargo-quickinstall](https://crates.io/crates/cargo-quickinstall) to this, once axum lands (it's currently a couple of typescript routes in a vercel app).

### Cargo.lock is dirty after building with no changes

This is mostly just distracting, but not a big deal. Could also be part of a CI check too?

## Commits

I also made some tweaks as I went along.

### "make bash snippets more copy-pastable"

GitHub renders a 'Copy' button, so adding $ makes things annoying.

I also changed the 'cd' path, assuming that you have just run
the command from the box above.

I can also make the same changes to https://docs.rs/shuttle-service/latest/shuttle_service/ if you want.