### PR TITLE
Gracefully shutdown service when running `cargo shuttle delete`

### DIFF
--- a/service/src/loader.rs
+++ b/service/src/loader.rs
@@ -50,7 +50,7 @@ impl Loader {
         self,
         factory: &mut dyn Factory,
         addr: SocketAddr,
-    ) -> Result<(ServeHandle, Library), Error> {
+    ) -> Result<(ServeHandle, Library, fn()), Error> {
         let mut service = self.service;
 
         service.build(factory)?;
@@ -59,7 +59,12 @@ impl Loader {
         // however that does not completely makes sense as the blocking call is made on another runtime.
         let handle = tokio::task::spawn_blocking(move || service.bind(addr));
 
-        Ok((handle, self.so))
+        // i want this
+        // let shutdown_handle = || service.shutdown();
+        // this is just a mock
+        let shutdown_handle = || {};
+
+        Ok((handle, self.so, shutdown_handle))
     }
 }
 


### PR DESCRIPTION
### The idea goes as follows:
1. grab server's shutdown handle, have it sitting on the receiver end of the `tokio::sync::oneshot` channel, and wrap everything in a tokio thread ([like here](https://github.com/getsynth/shuttle/commit/55a64e4cfdb88202e395302f1c9bc0068841221a#diff-a981df14dcb291acc010b3484e3911046bb9f568ebd28ed7c6c2bc4de23aa1faR420-R426))
2. assign transmiter end of the channel to [`SimpleService`'s field](https://github.com/getsynth/shuttle/commit/c3610f60403506f760f0a2142a9d034c515cbebd#diff-a981df14dcb291acc010b3484e3911046bb9f568ebd28ed7c6c2bc4de23aa1faR377) ([+ assignment itself](https://github.com/getsynth/shuttle/commit/c3610f60403506f760f0a2142a9d034c515cbebd#diff-a981df14dcb291acc010b3484e3911046bb9f568ebd28ed7c6c2bc4de23aa1faR413)), then have it passed around `SimpleService ==> dyn Service ==> Loader::load ==> DeploymentState ==> fn kill_deployment`
3. send value trought the channel to shutdown the service

### Current status:
Still validating PoC, expect to find some nonsense. 

[First approach](https://github.com/getsynth/shuttle/commit/c3610f60403506f760f0a2142a9d034c515cbebd) was kinda nice looking, but couldn't figure out how to walk around the issue of grabbing function pointer to trait object ([here](https://github.com/getsynth/shuttle/commit/c3610f60403506f760f0a2142a9d034c515cbebd#diff-a97dd9bb823b0963666fdfa86931d31afe901935b6a5d20686e7122199f2a315R62-R65)). Second approach (HEAD aka 55a64e4) looks like it's complete solution and compiles, but throws an error when trying to `deploy` hello-world example 
```
shuttle-app-1  | 2022-04-08 01:58:28,876 DEBG fd 9 closed, stopped monitoring <POutputDispatcher at 140577858553040 for <Subprocess at 140577858488152 with name shuttle-api in state STARTING> (stdout)>
```
not sure how to debug it yet...


### References (shutdown handles):
- [axum-server graceful_shutdown](https://docs.rs/axum-server/latest/src/graceful_shutdown/graceful_shutdown.rs.html#42)
- [Rocket (stage: `Ignite`)](https://docs.rs/rocket/0.5.0-rc.1/rocket/struct.Rocket.html#method.shutdown)
- [Rocket (stage: `Orbit`)](https://docs.rs/rocket/0.5.0-rc.1/rocket/struct.Rocket.html#method.shutdown-1)
